### PR TITLE
Add TopicEvent coverage endpoint

### DIFF
--- a/src/app/repository/topic_event.py
+++ b/src/app/repository/topic_event.py
@@ -1,0 +1,89 @@
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import joinedload
+
+from app.models.article import Article
+from app.models.source import Source
+from app.models.topic_event import TopicEvent
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+class TopicEventRepository:
+    @staticmethod
+    def get_by_id(db: "Session", topic_event_id: int) -> TopicEvent | None:
+        return (
+            db.query(TopicEvent)
+            .filter(TopicEvent.id == topic_event_id)
+            .first()
+        )
+
+    @staticmethod
+    def get_coverage(
+        db: "Session",
+        topic_event_id: int,
+        country_ids: list[int] | None = None,
+        limit: int = 5,
+    ) -> dict:
+        query = (
+            db.query(Article)
+            .options(
+                joinedload(Article.source).joinedload(Source.country),
+                joinedload(Article.topic_event),
+            )
+            .join(Source, Article.source_id == Source.id)
+            .filter(Article.topic_event_id == topic_event_id)
+            .order_by(Article.published_at.desc())
+        )
+
+        if country_ids:
+            query = query.filter(Source.country_id.in_(country_ids))
+
+        articles = query.all()
+
+        coverage_by_country: dict[int, dict] = {}
+
+        for article in articles:
+            if not article.source or not article.source.country:
+                continue
+
+            country = article.source.country
+
+            if country.id not in coverage_by_country:
+                coverage_by_country[country.id] = {
+                    "country": {
+                        "id": country.id,
+                        "code": country.code,
+                        "name": country.name,
+                        "language": country.language,
+                    },
+                    "articles": [],
+                }
+
+            if len(coverage_by_country[country.id]["articles"]) < limit:
+                coverage_by_country[country.id]["articles"].append(
+                    {
+                        "id": article.id,
+                        "title": article.title,
+                        "url": article.url,
+                        "published_at": article.published_at,
+                        "summary": article.summary,
+                        "image_url": article.image_url,
+                        "source": {
+                            "id": article.source.id,
+                            "name": article.source.name,
+                            "domain": article.source.domain,
+                            "country_id": article.source.country_id,
+                            "region_id": article.source.region_id,
+                        },
+                        "topic_id": article.topic_id,
+                        "region_id": article.region_id,
+                        "topic_event_id": article.topic_event_id,
+                    }
+                )
+
+        return {
+            "topic_event_id": topic_event_id,
+            "coverage": list(coverage_by_country.values()),
+        }

--- a/src/app/routes/topics.py
+++ b/src/app/routes/topics.py
@@ -1,4 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.repository.topic_event import TopicEventRepository
+
 
 api_router = APIRouter(prefix="/topics", tags=["topics"])
 
@@ -19,5 +24,20 @@ async def get_topics_by_id(id: int):
 
 
 @api_router.get("/{id}/coverage")
-async def get_topics_coverage(id: int):
-    return {"message": f"coverage for topic {id}"}
+async def get_topics_coverage(
+    id: int,
+    country_ids: list[int] | None = Query(default=None),
+    limit: int = Query(default=5, ge=1, le=20),
+    db: Session = Depends(get_db),
+):
+    topic_event = TopicEventRepository.get_by_id(db, id)
+
+    if not topic_event:
+        raise HTTPException(status_code=404, detail="Topic event not found")
+
+    return TopicEventRepository.get_coverage(
+        db=db,
+        topic_event_id=id,
+        country_ids=country_ids,
+        limit=limit,
+    )


### PR DESCRIPTION
Implements GET /topics/{id}/coverage.

- Adds TopicEventRepository coverage logic
- Groups articles by country using Source.country_id
- Supports optional country_ids filtering
- Supports per-country article limit