### PR TITLE
Fix user ownership enforcement and normalize article response schema

### DIFF
--- a/src/app/routes/articles.py
+++ b/src/app/routes/articles.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import Annotated
 from app.core.database import get_db
 from app.services.article import get_article_by_id, get_articles
-from app.schemas.article import ArticleResponse, ArticleSearchResponse
+from app.schemas.article import ArticleRead, ArticleSearchResponse
 
 api_router = APIRouter(prefix="/articles", tags=["articles"])
 
@@ -30,8 +30,8 @@ def search_articles(
     )
 
 
-@api_router.get("/{id}", response_model=ArticleResponse)
-async def get_article(id: int, db: Session = Depends(get_db)) -> ArticleResponse:
+@api_router.get("/{id}", response_model=ArticleRead)
+async def get_article(id: int, db: Session = Depends(get_db)) -> ArticleRead:
     return get_article_by_id(db, id)
 
 

--- a/src/app/routes/user.py
+++ b/src/app/routes/user.py
@@ -33,7 +33,8 @@ async def update_user(
     current_user: Annotated[UserSchema, Depends(get_current_user)],
     user_data: UserCreate,
 ):
-
+    if current_user.id != id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to update this user.")
     return user_service.update(db, id, user_data)
 
 
@@ -43,4 +44,6 @@ async def delete_user(
     id: int,
     current_user: Annotated[UserSchema, Depends(get_current_user)],
 ):
+    if current_user.id != id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to delete this user.")
     user_service.delete(db, id)

--- a/src/app/services/article.py
+++ b/src/app/services/article.py
@@ -2,7 +2,6 @@ from sqlalchemy.orm import Session
 
 from app.repository.article import ArticleRepository
 from app.schemas.article import ArticleSearchResponse
-from app.repository.country import CountryRepository
 from fastapi import HTTPException, status
 
 


### PR DESCRIPTION
- Add 403 check to PUT/DELETE /users/{id} so users can only modify their own account
- Switch GET /articles/{id} response from flat ArticleResponse to nested ArticleRead, consistent with the search endpoint
- Remove unused CountryRepository import from article service